### PR TITLE
enable socket example on K64F

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ add_subdirectory(hal)
 add_subdirectory(platform)
 add_subdirectory(targets)
 
+add_subdirectory(features)
+add_subdirectory(components)
+
 # Add additional modules
 get_property(modules GLOBAL PROPERTY MBED_OS_MODULES)
 

--- a/cmake/target.cmake
+++ b/cmake/target.cmake
@@ -8,7 +8,7 @@ set_property(GLOBAL PROPERTY MBED_OS_TARGET_LINKER_FILE "")
 # TODO: @mbed-os-tools This needs to come from tools
 # Build system provides "target" list.
 # Note: This must be placed before subdirectories
-set_property(GLOBAL PROPERTY MBED_OS_TARGET_LABELS Freescale;MCUXpresso_MCUS;KSDK2_MCUS;FRDM;KPSDK_MCUS;KPSDK_CODE;MCU_K64F;Freescale_EMAC;PSA;CORTEX_M;RTOS_M4_M7)
+set_property(GLOBAL PROPERTY MBED_OS_TARGET_LABELS Freescale;MCUXpresso_MCUS;KSDK2_MCUS;FRDM;KPSDK_MCUS;KPSDK_CODE;MCU_K64F;Freescale_EMAC;PSA;CORTEX_M;RTOS_M4_M7;K64F)
 
 # TODO: @mbed-os-tools Generate definitions
 add_definitions(
@@ -71,6 +71,7 @@ add_definitions(
   -DTARGET_RTOS_M4_M7
   -DTOOLCHAIN_GCC
   -DTOOLCHAIN_GCC_ARM
+  -DMBEDTLS_MD5_C
   -D__CMSIS_RTOS
   -D__CORTEX_M4
   -D__FPU_PRESENT=1

--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_include_directories(mbed-os PRIVATE TARGET_PSA/inc)
+target_include_directories(mbed-os PRIVATE TARGET_PSA/services/storage/its)

--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(frameworks/mbed-trace)
+
+target_link_libraries(mbedTrace PRIVATE gen_config)
+target_link_libraries(mbed-os PUBLIC mbedTrace)
+
+add_subdirectory(lwipstack)
+add_subdirectory(mbedtls)
+add_subdirectory(frameworks/mbed-client-randlib)
+add_subdirectory(frameworks/nanostack-libservice)
+add_subdirectory(netsocket)
+add_subdirectory(nanostack)
+
+target_include_directories(mbed-os PUBLIC .)

--- a/features/frameworks/mbed-client-randlib/CMakeLists.txt
+++ b/features/frameworks/mbed-client-randlib/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE
+    source/randLIB.c
+    mbed-client-randlib/randLIB.h
+    mbed-client-randlib/platform/arm_hal_random.h
+)
+target_include_directories(mbed-os PRIVATE mbed-client-randlib)
+target_include_directories(mbed-os PRIVATE mbed-client-randlib/platform)

--- a/features/frameworks/mbed-trace/CMakeLists.txt
+++ b/features/frameworks/mbed-trace/CMakeLists.txt
@@ -5,14 +5,14 @@ SET(CMAKE_SYSTEM_NAME Generic)
 
 project(mbedTrace)
 
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/mbed-trace/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../nanostack-libservice/mbed-client-libservice/)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../nanostack-libservice/)
 
 set (MBED_TRACE_SRC ${CMAKE_CURRENT_SOURCE_DIR}/source/mbed_trace.c)
 
 
-CREATE_LIBRARY(mbedTrace "${MBED_TRACE_SRC}" "")
+add_library(mbedTrace "${MBED_TRACE_SRC}" "")
 
+target_include_directories(mbedTrace PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(mbedTrace PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-trace)

--- a/features/frameworks/nanostack-libservice/CMakeLists.txt
+++ b/features/frameworks/nanostack-libservice/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE 
+    mbed-client-libservice/common_functions.h
+    mbed-client-libservice/ip4string.h
+    mbed-client-libservice/ip6string.h
+    mbed-client-libservice/ip_fsc.h
+    mbed-client-libservice/ns_list.h
+    mbed-client-libservice/ns_nvm_helper.h
+    mbed-client-libservice/ns_trace.h
+    mbed-client-libservice/ns_types.h
+    mbed-client-libservice/nsdynmemLIB.h
+    mbed-client-libservice/platform/arm_hal_interrupt.h
+    mbed-client-libservice/platform/arm_hal_nvm.h
+    source/IPv6_fcf_lib
+    source/IPv6_fcf_lib/ip_fsc.c
+    source/libBits/common_functions.c
+    source/libList/ns_list.c
+    source/libTrace/scripts/fetch_groups.sh
+    source/libip4string/ip4tos.c
+    source/libip4string/stoip4.c
+    source/libip6string/ip6tos.c
+    source/libip6string/stoip6.c
+    source/nsdynmemLIB/nsdynmemLIB.c
+    source/nvmHelper/ns_nvm_helper.c
+)
+target_include_directories(mbed-os PRIVATE mbed-client-libservice)
+target_include_directories(mbed-os PRIVATE mbed-client-libservice/platform)

--- a/features/lwipstack/CMakeLists.txt
+++ b/features/lwipstack/CMakeLists.txt
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE
+    lwip/src/api/lwip_api_lib.c
+    lwip/src/api/lwip_api_msg.c
+    lwip/src/api/lwip_err.c
+    lwip/src/api/lwip_if_api.c
+    lwip/src/api/lwip_netbuf.c
+    lwip/src/api/lwip_netdb.c
+    lwip/src/api/lwip_netifapi.c
+    lwip/src/api/lwip_sockets.c
+    lwip/src/api/lwip_tcpip.c
+    lwip/src/core/ipv4/lwip_autoip.c
+    lwip/src/core/ipv4/lwip_dhcp.c
+    lwip/src/core/ipv4/lwip_etharp.c
+    lwip/src/core/ipv4/lwip_icmp.c
+    lwip/src/core/ipv4/lwip_igmp.c
+    lwip/src/core/ipv4/lwip_ip4.c
+    lwip/src/core/ipv4/lwip_ip4_addr.c
+    lwip/src/core/ipv4/lwip_ip4_frag.c
+    lwip/src/core/ipv6/lwip_dhcp6.c
+    lwip/src/core/ipv6/lwip_ethip6.c
+    lwip/src/core/ipv6/lwip_icmp6.c
+    lwip/src/core/ipv6/lwip_inet6.c
+    lwip/src/core/ipv6/lwip_ip6.c
+    lwip/src/core/ipv6/lwip_ip6_addr.c
+    lwip/src/core/ipv6/lwip_ip6_frag.c
+    lwip/src/core/ipv6/lwip_mld6.c
+    lwip/src/core/ipv6/lwip_nd6.c
+    lwip/src/core/lwip_altcp.c
+    lwip/src/core/lwip_altcp_alloc.c
+    lwip/src/core/lwip_altcp_tcp.c
+    lwip/src/core/lwip_def.c
+    lwip/src/core/lwip_dns.c
+    lwip/src/core/lwip_inet_chksum.c
+    lwip/src/core/lwip_init.c
+    lwip/src/core/lwip_ip.c
+    lwip/src/core/lwip_mem.c
+    lwip/src/core/lwip_memp.c
+    lwip/src/core/lwip_netif.c
+    lwip/src/core/lwip_pbuf.c
+    lwip/src/core/lwip_raw.c
+    lwip/src/core/lwip_stats.c
+    lwip/src/core/lwip_sys.c
+    lwip/src/core/lwip_tcp.c
+    lwip/src/core/lwip_tcp_in.c
+    lwip/src/core/lwip_tcp_out.c
+    lwip/src/core/lwip_timeouts.c
+    lwip/src/core/lwip_udp.c
+    lwip/src/netif/lwip_bridgeif.c
+    lwip/src/netif/lwip_bridgeif_fdb.c
+    lwip/src/netif/lwip_ethernet.c
+    lwip/src/netif/lwip_lowpan6.c
+    lwip/src/netif/lwip_lowpan6_ble.c
+    lwip/src/netif/lwip_lowpan6_common.c
+    lwip/src/netif/lwip_slipif.c
+    lwip/src/netif/lwip_zepif.c
+    lwipopts.h
+)
+
+target_include_directories(mbed-os PUBLIC lwip/src/include)
+target_include_directories(mbed-os PUBLIC lwip/src/include/lwip)
+
+target_include_directories(mbed-os PUBLIC .)
+mbed_add_cmake_directory_if_labels("COMPONENT")
+
+target_sources(mbed-os PRIVATE
+    lwip-sys/arch/cc.h
+    lwip-sys/arch/lwip_checksum.c
+    lwip-sys/arch/lwip_memcpy.c
+    lwip-sys/arch/lwip_sys_arch.c
+    lwip-sys/arch/perf.h
+    lwip-sys/arch/sys_arch.h
+    lwip-sys/lwip_random.c
+    lwip-sys/lwip_random.h
+    lwip-sys/lwip_tcp_isn.c
+    lwip-sys/lwip_tcp_isn.h
+    lwip_tools.cpp
+    lwip_tools.h
+    LWIPInterface.cpp
+    LWIPInterfaceEMAC.cpp
+    LWIPInterfaceL3IP.cpp
+    LWIPInterfacePPP.cpp
+    LWIPMemoryManager.cpp
+    LWIPMemoryManager.h
+    LWIPStack.cpp
+    LWIPStack.h
+)
+
+target_include_directories(mbed-os PUBLIC lwip-sys)
+target_include_directories(mbed-os PUBLIC lwip-sys/arch)

--- a/features/mbedtls/CMakeLists.txt
+++ b/features/mbedtls/CMakeLists.txt
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(mbed-crypto)
+
+mbed_add_cmake_directory_if_labels("platform/TARGET")
+
+target_sources(mbed-os PRIVATE platform/src/mbed_trng.cpp)
+
+target_include_directories(mbed-os PRIVATE .)
+target_include_directories(mbed-os PRIVATE inc)

--- a/features/mbedtls/mbed-crypto/CMakeLists.txt
+++ b/features/mbedtls/mbed-crypto/CMakeLists.txt
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE
+    src/aes.c
+    src/aesni.c
+    src/arc4.c
+    src/aria.c
+    src/asn1parse.c
+    src/asn1write.c
+    src/base64.c
+    src/bignum.c
+    src/blowfish.c
+    src/camellia.c
+    src/ccm.c
+    src/chacha20.c
+    src/chachapoly.c
+    src/cipher.c
+    src/cipher_wrap.c
+    src/cmac.c
+    src/ctr_drbg.c
+    src/des.c
+    src/dhm.c
+    src/ecdh.c
+    src/ecdsa.c
+    src/ecjpake.c
+    src/ecp.c
+    src/ecp_curves.c
+    src/entropy.c
+    src/entropy_poll.c
+    src/gcm.c
+    src/havege.c
+    src/hkdf.c
+    src/hmac_drbg.c
+    src/md.c
+    src/md2.c
+    src/md4.c
+    src/md5.c
+    src/memory_buffer_alloc.c
+    src/nist_kw.c
+    src/oid.c
+    src/padlock.c
+    src/pem.c
+    src/pk.c
+    src/pk_wrap.c
+    src/pkcs12.c
+    src/pkcs5.c
+    src/pkparse.c
+    src/pkwrite.c
+    src/platform.c
+    src/platform_util.c
+    src/poly1305.c
+    src/ripemd160.c
+    src/rsa.c
+    src/rsa_internal.c
+    src/sha1.c
+    src/sha256.c
+    src/sha512.c
+    src/threading.c
+    src/timing.c
+    src/xtea.c
+)
+target_include_directories(mbed-os PRIVATE inc)
+target_include_directories(mbed-os PRIVATE inc/psa)

--- a/features/mbedtls/platform/TARGET_PSA/CMakeLists.txt
+++ b/features/mbedtls/platform/TARGET_PSA/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+mbed_add_cmake_directory_if_labels("COMPONENT")

--- a/features/nanostack/CMakeLists.txt
+++ b/features/nanostack/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(nanostack-hal-mbed-cmsis-rtos)
+add_subdirectory(sal-stack-nanostack)
+add_subdirectory(sal-stack-nanostack-eventloop)

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/CMakeLists.txt
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE 
+    arm_hal_fhss_timer.cpp
+    arm_hal_interrupt.c
+    arm_hal_interrupt_private.h
+    arm_hal_random.c
+    arm_hal_timer.cpp
+    ns_event_loop.c
+    ns_event_loop.h
+    ns_event_loop_mbed.cpp
+    ns_event_loop_mutex.c
+    ns_event_loop_mutex.h
+    ns_hal_init.c
+    ns_hal_init.h
+    nvm/nvm_ram.c
+)

--- a/features/nanostack/sal-stack-nanostack-eventloop/CMakeLists.txt
+++ b/features/nanostack/sal-stack-nanostack-eventloop/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os PRIVATE nanostack-event-loop)

--- a/features/nanostack/sal-stack-nanostack/CMakeLists.txt
+++ b/features/nanostack/sal-stack-nanostack/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os PRIVATE nanostack)

--- a/features/netsocket/CMakeLists.txt
+++ b/features/netsocket/CMakeLists.txt
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE
+    #CellularInterface.h
+    #CellularNonIPSocket.cpp
+    #CellularNonIPSocket.h
+    #OnboardNetworkStack.h
+    #ppp
+    #PPP.h
+    #PPPInterface.cpp
+    #PPPInterface.h
+
+    NetworkInterface.cpp
+    NetworkInterfaceDefaults.cpp
+    NetworkInterface.h
+    NetworkStack.cpp
+    NetworkStack.h
+    nsapi_dns.cpp
+    nsapi_dns.h
+    nsapi.h
+    nsapi_ppp.h
+    nsapi_types.h
+    NetStackMemoryManager.cpp
+    NetStackMemoryManager.h
+    ControlPlane_netif.h
+    SocketAddress.cpp
+    SocketAddress.h
+    Socket.h
+    SocketStats.cpp
+    SocketStats.h
+
+    emac-drivers
+    EMAC.h
+    EMACInterface.cpp
+    EMACInterface.h
+    EMACMemoryManager.h
+
+    EthernetInterface.cpp
+    EthernetInterface.h
+    EthInterface.h
+
+    DNS.h
+    ICMPSocket.cpp
+    ICMPSocket.h
+    UDPSocket.cpp
+    UDPSocket.h
+    TCPServer.cpp
+    TCPServer.h
+    TCPSocket.cpp
+    TCPSocket.h
+    TLSSocket.cpp
+    TLSSocket.h
+    TLSSocketWrapper.cpp
+    TLSSocketWrapper.h
+    DTLSSocket.cpp
+    DTLSSocket.h
+    DTLSSocketWrapper.cpp
+    DTLSSocketWrapper.h
+
+    InternetDatagramSocket.cpp
+    InternetDatagramSocket.h
+
+    InternetSocket.cpp
+    InternetSocket.h
+
+    #L3IP.h
+    #L3IPInterface.cpp
+    #L3IPInterface.h
+
+    #MeshInterface.h
+
+
+    #WiFiAccessPoint.cpp
+    #WiFiAccessPoint.h
+    #WiFiInterface.h
+)
+target_include_directories(mbed-os PUBLIC .)
+mbed_add_cmake_directory_if_labels("emac-drivers/TARGET")

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/CMakeLists.txt
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/CMakeLists.txt
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE
+    kinetis_emac.cpp
+    kinetis_emac.h
+    kinetis_emac_config.h
+)
+mbed_add_cmake_directory_if_labels("TARGET")

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/TARGET_K64F/CMakeLists.txt
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/TARGET_K64F/CMakeLists.txt
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0
+
+target_sources(mbed-os PRIVATE hardware_init_MK64F12.c)


### PR DESCRIPTION
### Summary of changes <!-- Required -->

adds cmakelists to build mbed-os-socket-example for K64F using cmake.
