### PR TITLE
Enable KV storage build with CMake

### DIFF
--- a/components/CMakeLists.txt
+++ b/components/CMakeLists.txt
@@ -1,2 +1,4 @@
+add_subdirectory(storage)
+
 target_include_directories(mbed-os PUBLIC TARGET_PSA/inc)
 target_include_directories(mbed-os PUBLIC TARGET_PSA/services/storage/its)

--- a/components/storage/CMakeLists.txt
+++ b/components/storage/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(blockdevice)

--- a/components/storage/blockdevice/CMakeLists.txt
+++ b/components/storage/blockdevice/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_sources(mbed-os
+	PRIVATE
+		COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+		COMPONENT_SD/SDBlockDevice.cpp
+)

--- a/features/CMakeLists.txt
+++ b/features/CMakeLists.txt
@@ -11,5 +11,7 @@ add_subdirectory(frameworks/mbed-client-randlib)
 add_subdirectory(frameworks/nanostack-libservice)
 add_subdirectory(netsocket)
 add_subdirectory(nanostack)
+add_subdirectory(storage)
+add_subdirectory(device_key)
 
 target_include_directories(mbed-os PUBLIC .)

--- a/features/device_key/CMakeLists.txt
+++ b/features/device_key/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os
+	PUBLIC
+		source
+)
+
+target_sources(mbed-os
+	PRIVATE
+		source/DeviceKey.cpp
+)

--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include "platform/mbed_error.h"
 #include <string.h>
-#include "entropy.h"
+#include "mbedtls/entropy.h"
 #include "mbed_trace.h"
 
 #define TRACE_GROUP "DEVKEY"

--- a/features/storage/CMakeLists.txt
+++ b/features/storage/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+add_subdirectory(blockdevice)
+add_subdirectory(filesystem)
+add_subdirectory(kvstore)

--- a/features/storage/blockdevice/CMakeLists.txt
+++ b/features/storage/blockdevice/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_sources(mbed-os
+	PRIVATE
+		BufferedBlockDevice.cpp
+		FlashSimBlockDevice.cpp
+		SlicingBlockDevice.cpp
+)

--- a/features/storage/filesystem/CMakeLists.txt
+++ b/features/storage/filesystem/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os
+	PUBLIC
+		${CMAKE_CURRENT_SOURCE_DIR}
+		fat
+		littlefs
+)
+
+target_sources(mbed-os
+	PRIVATE
+		Dir.cpp
+		File.cpp
+		FileSystem.cpp
+		fat/FATFileSystem.cpp
+		fat/ChaN/ff.cpp
+		fat/ChaN/ffunicode.cpp
+		littlefs/LittleFileSystem.cpp
+)

--- a/features/storage/kvstore/CMakeLists.txt
+++ b/features/storage/kvstore/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+target_include_directories(mbed-os
+	PUBLIC
+		conf
+		global_api
+		filesystemstore
+		include
+		kv_map
+		securestore
+		tdbstore
+)
+
+target_sources(mbed-os
+	PRIVATE
+		conf/kv_config.cpp
+		filesystemstore/FileSystemStore.cpp
+		global_api/kvstore_global_api.cpp
+		kv_map/KVMap.cpp
+		securestore/SecureStore.cpp
+		tdbstore/TDBStore.cpp
+)

--- a/features/storage/kvstore/securestore/SecureStore.cpp
+++ b/features/storage/kvstore/securestore/SecureStore.cpp
@@ -20,10 +20,10 @@
 
 #if SECURESTORE_ENABLED
 
-#include "aes.h"
-#include "cmac.h"
+#include "mbedtls/aes.h"
+#include "mbedtls/cmac.h"
 #include "mbedtls/platform.h"
-#include "entropy.h"
+#include "mbedtls/entropy.h"
 #include "DeviceKey.h"
 #include "mbed_assert.h"
 #include "mbed_wait_api.h"

--- a/mbed.h
+++ b/mbed.h
@@ -32,7 +32,7 @@
 #endif
 
 #if MBED_CONF_FILESYSTEM_PRESENT
-#include "filesystem/mbed_filesystem.h"
+#include "features/storage/filesystem/mbed_filesystem.h"
 #endif
 
 #include "platform/mbed_toolchain.h"


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Enable the kvstore global API to be build with CMake when used in project.

----------------------------------------------------------------------------------------------------------------
### Test result

Could build a [modified branch of `mbed-os-example-kvstore`](https://github.com/hugueskamba/mbed-os-example-kvstore/tree/dev_cmake) after generating the Makefile with CMake as follows:

1. From `mbed-os-example-kvstore`, run the following:
```
$ mkdir build && cd build && cmake .. && make
```
 
#### Output

```
Scanning dependencies of target app
[100%] Building CXX object CMakeFiles/app.dir/main.cpp.obj
In file included from /Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./mbed.h:73,
                 from /Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/main.cpp:18:
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:177:5: warning: 'virtual int mbed::UARTSerial::set_blocking(bool)' is deprecated: The class has been deprecated and will be removed in the future. [-Wdeprecated-declarations]
     }
     ^
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:173:17: note: declared here
     virtual int set_blocking(bool blocking)
                 ^~~~~~~~~~~~
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:188:5: warning: 'virtual bool mbed::UARTSerial::is_blocking() const' is deprecated: The class has been deprecated and will be removed in the future. [-Wdeprecated-declarations]
     }
     ^
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:185:18: note: declared here
     virtual bool is_blocking() const
                  ^~~~~~~~~~~
[100%] Linking CXX executable app
-- built: /Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/build/app.bin
[100%] Built target app
``` 

The application runs as expected.
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@bulislaw @0xc0170
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
