### PR TITLE
Enable little filesystem storage build with CMake

### DIFF
--- a/features/storage/filesystem/CMakeLists.txt
+++ b/features/storage/filesystem/CMakeLists.txt
@@ -6,6 +6,7 @@ target_include_directories(mbed-os
 		${CMAKE_CURRENT_SOURCE_DIR}
 		fat
 		littlefs
+		littlefs/littlefs
 )
 
 target_sources(mbed-os
@@ -17,4 +18,5 @@ target_sources(mbed-os
 		fat/ChaN/ff.cpp
 		fat/ChaN/ffunicode.cpp
 		littlefs/LittleFileSystem.cpp
+		littlefs/littlefs/lfs.c
 )


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->
Enable the little filesystem API to be build with CMake as part of the Mbed OS library.

----------------------------------------------------------------------------------------------------------------
### Test result

Could build a [modified branch of `mbed-os-example-kvstore`](https://github.com/hugueskamba/mbed-os-example-kvstore/tree/dev_cmake) after generating the Makefile with CMake as follows:

1. Replace the content of `main.cpp` with the following:
```
#include "mbed.h"
#include "features/storage/filesystem/littlefs/LittleFileSystem.h"
#include "components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h"

int main() {
    SDBlockDevice sd_card(PTE3, PTE1, PTE2, PTE4); 
    LittleFileSystem fs("fs");
    if (fs.mount(&sd_card)) {
        if (LittleFileSystem::format(&sd_card)) fs.mount(&sd_card);
        else return -1;
    }
    char file_path[] = "/fs/boot_count";
    uint32_t boot_count = 0;
    FILE *f = fopen(file_path, "ab+");
    fread(&boot_count, sizeof(boot_count), 1, f);
    rewind(f);
    fwrite(&(++boot_count), sizeof(boot_count), 1, f);
    fclose(f);
    fs.unmount();
    printf("boot_count: %ld\n", boot_count);
}

```
2. From `mbed-os-example-kvstore`, run the following:
```
$ mkdir build && cd build && cmake .. && make
```
 
#### Output

```
[100%] Built target mbed-os
Scanning dependencies of target app
[100%] Building CXX object CMakeFiles/app.dir/main.cpp.obj
In file included from /Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./mbed.h:73,
                 from /Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/main.cpp:18:
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:177:5: warning: 'virtual int mbed::UARTSerial::set_blocking(bool)' is deprecated: The class has been deprecated and will be removed in the future. [-Wdeprecated-declarations]
     }
     ^
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:173:17: note: declared here
     virtual int set_blocking(bool blocking)
                 ^~~~~~~~~~~~
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:188:5: warning: 'virtual bool mbed::UARTSerial::is_blocking() const' is deprecated: The class has been deprecated and will be removed in the future. [-Wdeprecated-declarations]
     }
     ^
/Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/mbed-os/./drivers/UARTSerial.h:185:18: note: declared here
     virtual bool is_blocking() const
                  ^~~~~~~~~~~
[100%] Linking CXX executable app
-- built: /Users/hugkam01/projects/mbed/examples/mbed-os-example-kvstore/build/app.bin
[100%] Built target app
``` 

The application needs to be tested on a K64F.
 
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->
@bulislaw @0xc0170
<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
