### PR TITLE
Testing this

### DIFF
--- a/cmake-naming.md
+++ b/cmake-naming.md
@@ -1,0 +1,36 @@
+## CMake targets for Mbed "targets"
+
+### targets.json naming scheme
+
+- `MCU_STM32L4` - base target
+- `DISCO_L4R9I` - final target - a user board or could be custom target, inherits from MCU_  target
+
+The targets.json properties use capital letters with underscore but not the our config. Probably to distinguish these from other regular directories (the initial Mbed SDK had it this way).
+
+### CMake naming scheme
+
+All Mbed OS CMake targets are prefixed with `mbed-` to avoid clashes with user's targets (out of the tree targets): `mbed-ble`, `mbed-nanostack`.
+
+Mbed OS targets should follow the same scheme in CMake.
+
+- `mbed-target-stm32-mcu-stm32l4` - base target
+- `mbed-target-stm32-disco-l4r9i` - final target - a user board or could be custom target, inherits from MCU_  target
+
+If we are not consistent with naming, we would have targets different named than the rest of the tree in Mbed OS and potentionally also in the user space.
+
+To consider how this looks with the package manager - the namespacing packages is a good thing (we had it in yotta). We should add `mbed`, `target` and `vendor` at least to the CMake target.
+
+We will refactor targets directories once the old tools are gone. It will help us to reduce the paths in Mbed OS drastically. This will be our chance to also rename directories, not following the old scheme (if we decide it's a good change to apply the new scheme to targets).
+
+An example what we can actually do with renaming:
+
+`targets/TARGET_STM32/TARGET_STM32L4/TARGET_MCU_STM32L4` could be changed to `targets/stm32/stm32l4/mcu-stm32l4`. 
+
+This allows us to get rid of the name equals directory structure (our tools are not enforcing it anymore). We do not need stm32l4 in the name just because there is a directory in the tree. We can create more logical target structure.
+
+#### Targets translation
+
+targets.json keeps its naming scheme. I do not think we are at the stage to refactor it.
+ What we can do however is to keep our CMake naming in `targets` folder.
+
+ We provide in CMake the translation from targets.json to cmake targets.

--- a/cmake-naming.md
+++ b/cmake-naming.md
@@ -36,3 +36,9 @@ CMakelists for each vendor would have the logic to select the proper target. As 
 `mbed_target_get_vendor()` contains our vendors supported to return valid vendor name
 
 `mbed_target_get_cmake_name()` function would just do string replace, to keep things simple.
+
+
+### Footnotes
+
+This is a simplistic view to targets hiearchy, the subject is much more complicated than what is presented here. Creating a manageable targets hierarchy with so many different vendors is not trivial. This is out of the scope for this naming scheme proposal. The aim so to provide the way to use what we have and just translate it to CMake to keep things consistent. Not to change targets.json file, at least for now.
+ We looked at it once with Mbed 3 as we hit a problem with targets naming - how to properly namespace targets, how to simplify the very complicated MCU family tree like STM has for instance.

--- a/cmake-naming.md
+++ b/cmake-naming.md
@@ -1,30 +1,28 @@
-## CMake targets for Mbed "targets"
+## CMake targets for Mbed targets
 
-### targets.json naming scheme
+### Target configuration file naming scheme
 
-- `MCU_STM32L4` - base target
-- `DISCO_L4R9I` - final target - a user board or could be custom target, inherits from MCU_  target
+Default attributes of Mbed targets are defined in `targets/targets.json`, these include the name of the target.
+
+Mbed targets usually inherit their properties from a "base" target which represents a family of targets that share similar properties. For example the `DISCO_L4R9I` Mbed board has the `MCU_STM32L4` as its base target.
 
 The targets.json properties use capital letters with underscore but not the our config. Probably to distinguish these from other regular directories (the initial Mbed SDK had it this way).
 
-### CMake naming scheme
+### CMake target naming scheme
 
 All Mbed OS CMake targets are prefixed with `mbed-` to avoid clashes with user's targets (out of the tree targets): `mbed-ble`, `mbed-nanostack`.
 
-Mbed OS targets should follow the same scheme in CMake.
+Mbed targets should follow the same scheme in CMake. For example the `DISCO_L4R9I` Mbed board should have a CMake target named `mbed-target-stm32-disco-l4r9i` with a dependency on a `mbed-target-stm32-mcu-stm32l4` base CMake target.
 
 - `mbed-target-stm32-mcu-stm32l4` - base target
 - `mbed-target-stm32-disco-l4r9i` - final target - a user board or could be custom target, inherits from MCU_  target
 
-If we are not consistent with naming, we would have targets different named than the rest of the tree in Mbed OS and potentionally also in the user space.
+Consistency in naming is a must to avoid having CMake targets with names different than the rest of the Mbed OS repository tree and in the user space.
 
 To consider how this looks with the package manager - the namespacing packages is a good thing (we had it in yotta). We should add `mbed`, `target` and `vendor` at least to the CMake target.
 
-We will refactor targets directories once the old tools are gone. It will help us to reduce the paths in Mbed OS drastically. This will be our chance to also rename directories, not following the old scheme (if we decide it's a good change to apply the new scheme to targets).
+We will refactor targets directories once the old tools are gone. It will drastically reduce the path lengths in Mbed OS. It will also provide an opportunity to rename directories without following the old naming scheme. For example, `targets/TARGET_STM32/TARGET_STM32L4/TARGET_MCU_STM32L4` could be become `targets/stm32/stm32l4/mcu-stm32l4`. 
 
-An example what we can actually do with renaming:
-
-`targets/TARGET_STM32/TARGET_STM32L4/TARGET_MCU_STM32L4` could be changed to `targets/stm32/stm32l4/mcu-stm32l4`. 
 
 This allows us to get rid of the name equals directory structure (our tools are not enforcing it anymore). We do not need stm32l4 in the name just because there is a directory in the tree. We can create more logical target structure.
 
@@ -33,4 +31,4 @@ This allows us to get rid of the name equals directory structure (our tools are 
 targets.json keeps its naming scheme. I do not think we are at the stage to refactor it.
  What we can do however is to keep our CMake naming in `targets` folder.
 
- We provide in CMake the translation from targets.json to cmake targets.
+ The CMake input files map the Mbed target names used in `targets.json` to the directories in the Mbed OS repository.

--- a/cmake-naming.md
+++ b/cmake-naming.md
@@ -33,9 +33,9 @@ CMakelists for each vendor would have the logic to select the proper target. As 
         CMAKE_TARGET = mbed-target-$(mbed_target_get_vendor())-$(mbed_target_get_cmake_name())
     ```
 
-`mbed_target_get_vendor()` contains our vendors supported to return valid vendor name
+`mbed_target_get_vendor()` contains our vendors supported list, returns vendor name
 
-`mbed_target_get_cmake_name()` function would just do string replace, to keep things simple.
+`mbed_target_get_cmake_name()` function would just do string replace, returns CMake target name for specified Mbed OS target
 
 
 ### Footnotes


### PR DESCRIPTION
<!--
For more information on the requirements for pull requests, please see [the contributing guidelines](https://os.mbed.com/docs/mbed-os/latest/contributing/workflow.html).

NOTE: Do not remove any of the template headings (even for optional sections) as this
template is automatically parsed. 
-->

### Summary of changes <!-- Required -->

<!-- 
    Please provide the following information: 

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed (if this is fixing a reported issue please summarize what
    the issue is and add the reference. E.g. Fixes #17119).

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
    
-->

I don't like the naming scheme in targets.json as we started from the small set of targets until hunders of them and there was no clear guideline how to create MCU family and inherits etc. It came later and it resulted in non consistent targets.json.  From a target name, you do not know what vendor is it, what MCU family, nothing - it is not even in targets.json. Only source of truth there are TARGET_ labels - they carry some important information but its hidden from a user. The tree hierarchy in targets.json is basically flat with inheritance in some cases (couple of vendors only implemented it in the recent years).

We got the opportunity here to create at least more uniformed targets names that contain vendor name, mcu family and possibly other details that might be important to a vendor or a user.

#### Impact of changes <!-- Optional -->
<!-- 
    If there are any implications for users taking this change then they must be 
    provided here. For Major PR types this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

#### Migration actions required <!-- Optional -->
<!-- 
    This should only be applicable in Major PR types for which this field is MANDATORY.

    NOTE: This section is automatically written to release notes for Feature and 
    Major releases and should contain enough details for a user.
-->

### Documentation <!-- Required -->

<!-- 
    Please provide details of any document updates required, including links to any
    related PRs against the docs repository.
    If no document updates are required please specify 'None', this at least tells us
    that this has been considered.
-->

----------------------------------------------------------------------------------------------------------------
### Pull request type <!-- Required -->

<!--
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front of them would change the meaning incorrectly. 
-->
    [] Patch update (Bug fix / Target update / Docs update / Test update / Refactor)
    [] Feature update (New feature / Functionality change / New API)
    [] Major update (Breaking change E.g. Return code change / API behaviour change)

----------------------------------------------------------------------------------------------------------------
### Test results <!-- Required -->

<!--
    Provide all the information required, listing all the testing performed. For new targets please attach full test results for all supported compilers.
-->
    [] No Tests required for this change (E.g docs only update)
    [] Covered by existing mbed-os tests (Greentea or Unittest)
    [] Tests / results supplied as part of this PR
    
    
----------------------------------------------------------------------------------------------------------------
### Reviewers <!-- Optional -->

<!--
    Request additional reviewers with @username or @team
-->

----------------------------------------------------------------------------------------------------------------
